### PR TITLE
fix address - Aritra Saha

### DIFF
--- a/erc20.sol
+++ b/erc20.sol
@@ -63,8 +63,8 @@ contract QKCToken is ERC20Interface, SafeMath {
         name = "QuikNode Coin";
         decimals = 2;
         _totalSupply = 100000;
-        balances[YOUR_METAMASK_WALLET_ADDRESS] = _totalSupply;
-        emit Transfer(address(0), YOUR_METAMASK_WALLET_ADDRESS, _totalSupply);
+        balances[msg.sender] = _totalSupply;
+        emit Transfer(address(0), msg.sender, _totalSupply);
     }
  
     function totalSupply() public constant returns (uint) {


### PR DESCRIPTION
replaced YOUR_METAMASK_WALLET_ADDRESS with msg.sender - so while deploying the constructor will set the balance of the deploying address to _totalSupply