### PR TITLE
Fix-Updated the constructor initialisation

### DIFF
--- a/erc20.sol
+++ b/erc20.sol
@@ -63,8 +63,8 @@ contract QKCToken is ERC20Interface, SafeMath {
         name = "QuikNode Coin";
         decimals = 2;
         _totalSupply = 100000;
-        balances[YOUR_METAMASK_WALLET_ADDRESS] = _totalSupply;
-        emit Transfer(address(0), YOUR_METAMASK_WALLET_ADDRESS, _totalSupply);
+        balances[msg.sender] = _totalSupply;
+        emit Transfer(address(0), msg.sender, _totalSupply);
     }
  
     function totalSupply() public constant returns (uint) {


### PR DESCRIPTION
The variable YOUR_METAMASK_WALLET_ADDRESS has been replaced with msg.sender.
This is done to ensure that while deploying the smart contract, the constructor initialises the balance of the address this contract is being deployed to the variable _totalSupply