### PR TITLE
Updated code and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,21 @@ Welcome to Coding Quests
 
 Instructions on Coding Quests: 
 1. Fork the repository - {link to github} 
-2. Scout the code for errors and solve them
+2. Scout the code for errors and solve them 
 3. Once the code is solved, raise a PR with your name. 
 4. Once our team checks out the code we’ll merge the PR. 
 5. The code snippet is in Solidity.
+
+# Replacments 👾
+
+Replace **YOUR_METAMASK_WALLET_ADDRESS** with **msg.sender** which implies the address which is initiating the transaction.
+
+# Vulnerablity 😈
+
+This contract is using the function by ERC827 Token Standard. According to the official docs of ERC827 Token Standard, **"This standard is still a draft and is proven to be unsafe to be used"**. It allows the token to execute a function in the receiver contract  after the approval or transfer happens. Openzeppelin library has also removed this Token standard from their official Repo.
+
+**Best Practices for approveAndCall**
+
+**approveAndCall:** It allows the receiver contract to use approved balance. The best practice is to check the allowance of the sender and then do your stuff using the transferFromAndCall method.
+
+

--- a/erc20.sol
+++ b/erc20.sol
@@ -63,8 +63,8 @@ contract QKCToken is ERC20Interface, SafeMath {
         name = "QuikNode Coin";
         decimals = 2;
         _totalSupply = 100000;
-        balances[YOUR_METAMASK_WALLET_ADDRESS] = _totalSupply;
-        emit Transfer(address(0), YOUR_METAMASK_WALLET_ADDRESS, _totalSupply);
+        balances[msg.sender] = _totalSupply; //Replacing YOUR_METAMASK_WALLET_ADDRESS with msg.sender
+        emit Transfer(address(0), msg.sender, _totalSupply); //Replacing YOUR_METAMASK_WALLET_ADDRESS with msg.sender
     }
  
     function totalSupply() public constant returns (uint) {
@@ -100,12 +100,15 @@ contract QKCToken is ERC20Interface, SafeMath {
         return allowed[tokenOwner][spender];
     }
  
-    function approveAndCall(address spender, uint tokens, bytes data) public returns (bool success) {
-        allowed[msg.sender][spender] = tokens;
-        emit Approval(msg.sender, spender, tokens);
-        ApproveAndCallFallBack(spender).receiveApproval(msg.sender, tokens, this, data);
-        return true;
-    }
+    //  Commenting out this function, as his function is from ERC827 Token standard which is proven unsafe to use
+    //  It allows the token to execute a function in the receiver contract  after the approval or transfer happens.
+
+    // function approveAndCall(address spender, uint tokens, bytes data) public returns (bool success) {
+    //     allowed[msg.sender][spender] = tokens;
+    //     emit Approval(msg.sender, spender, tokens);
+    //     ApproveAndCallFallBack(spender).receiveApproval(msg.sender, tokens, this, data);
+    //     return true;
+    // }
  
     function () public payable {
         revert();


### PR DESCRIPTION

# Replacments 👾

Replace **YOUR_METAMASK_WALLET_ADDRESS** with **msg.sender** which implies the address which is initiating the transaction.

# Vulnerablity 😈

This contract is using the function by ERC827 Token Standard. According to the official docs of ERC827 Token Standard, **"This standard is still a draft and is proven to be unsafe to be used"**. It allows the token to execute a function in the receiver contract  after the approval or transfer happens. Openzeppelin library has also removed this Token standard from their official Repo.

**Best Practices for approveAndCall**

**approveAndCall:** It allows the receiver contract to use approved balance. The best practice is to check the allowance of the sender and then do your stuff using the transferFromAndCall method.
